### PR TITLE
fix: The microsite rewriter must be executed first

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"symfony/http-kernel": "^6.3 || ^7.0",
 		"symfony/yaml": "^6.3 || ^7.0",
 		"atoolo/rewrite-bundle": "^1.2",
-		"atoolo/resource-bundle": "^1.5"
+		"atoolo/resource-bundle": "^1.6"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,7 +7,8 @@ services:
 
   _instanceof:
     Atoolo\Rewrite\Service\UrlRewriterHandler:
-      tags: [ 'atoolo_rewrite.url_rewrite_handler' ]
+      tags:
+        - { name: 'atoolo_rewrite.url_rewrite_handler', priority: 20 }
 
   Atoolo\Microsite\Service\:
     resource: '../src/Service'

--- a/test/Factory/MicrositeContextFactoryTest.php
+++ b/test/Factory/MicrositeContextFactoryTest.php
@@ -49,6 +49,7 @@ class MicrositeContextFactoryTest extends TestCase
             configDir: '',
             searchIndex: '',
             translationLocales: [],
+            attributes: new DataBag([]),
             tenant: $this->createStub(ResourceTenant::class),
         );
         $this->rewriteContext = $this->createMock(UrlRewriteContext::class);


### PR DESCRIPTION
This is important because rewriting only works correctly if the path has not yet been manipulated.

Der Pfad wird mit den Evn-Variable `ATOOLO_MICROSITE_PATH` verglichen. Die URL wird nur als Micoriste-Url erkannt, wenn dieser Pfad übereinstimmt. Wurde die URL bereits manipuliert, z.B. durch einen Language-Prefix, scheitert der Vergleicht und die erzeugte URL ist nicht mehr korrekt.